### PR TITLE
bugfix uløselig aksjonspunkt

### DIFF
--- a/mock/inntektsmeldingPropsMock.ts
+++ b/mock/inntektsmeldingPropsMock.ts
@@ -149,3 +149,78 @@ export const aksjonspunkt9071Props = {
         },
     ],
 };
+export const aksjonspunkt9071FerdigProps = {
+    arbeidsforhold: {
+        896929119: {
+            identifikator: '896929119',
+            personIdentifikator: null,
+            navn: 'SAUEFABRIKK',
+            fødselsdato: null,
+            arbeidsforholdreferanser: [
+                {
+                    internArbeidsforholdId: '99ab90b6-98fd-4ab8-8632-fc08d8cb898e',
+                    eksternArbeidsforholdId: '2',
+                },
+            ],
+        },
+        972674818: {
+            identifikator: '972674818',
+            personIdentifikator: null,
+            navn: 'PENGELØS SPAREBANK',
+            fødselsdato: null,
+            arbeidsforholdreferanser: [
+                {
+                    internArbeidsforholdId: 'b8c8b29f-42da-4aef-9714-6fbc9772079f',
+                    eksternArbeidsforholdId: '1',
+                },
+            ],
+        },
+    },
+    endpoints: {
+        kompletthetBeregning: 'tilstand',
+    },
+    readOnly: false,
+    saksbehandlere: {
+        Z994142: 'F_Z994142 E_Z994142',
+        Z994895: 'F_Z994895 E_Z994895',
+        Z994158: 'F_Z994158 E_Z994158',
+    },
+    aksjonspunkter: [
+        {
+            aksjonspunktType: {
+                kode: 'MANU',
+                kodeverk: 'AKSJONSPUNKT_TYPE',
+            },
+            begrunnelse: null,
+            besluttersBegrunnelse: 'evvv',
+            definisjon: {
+                skalAvbrytesVedTilbakeføring: false,
+                kode: '9071',
+                kodeverk: 'AKSJONSPUNKT_DEF',
+            },
+            erAktivt: true,
+            fristTid: null,
+            kanLoses: true,
+            status: {
+                kode: 'UTFORT',
+                kodeverk: 'AKSJONSPUNKT_STATUS',
+            },
+            toTrinnsBehandling: true,
+            toTrinnsBehandlingGodkjent: false,
+            vilkarType: null,
+            vurderPaNyttArsaker: [
+                {
+                    kode: 'ANNET',
+                    kodeverk: 'VURDER_AARSAK',
+                },
+            ],
+            venteårsak: {
+                kanVelgesIGui: false,
+                kode: '-',
+                kodeverk: 'VENT_AARSAK',
+            },
+            venteårsakVariant: null,
+            opprettetAv: 'srvk9sak',
+        },
+    ],
+};

--- a/mock/mockedKompletthetsdata.ts
+++ b/mock/mockedKompletthetsdata.ts
@@ -175,3 +175,34 @@ export const ikkePaakrevd = {
         },
     ],
 };
+export const alleErMottatt = {
+    tilstand: [
+        {
+            periode: '2022-08-01/2022-08-04',
+            status: [
+                {
+                    arbeidsgiver: {
+                        arbeidsgiver: '896929119',
+                        arbeidsforhold: '2',
+                    },
+                    status: 'MOTTATT',
+                    journalpostId: null,
+                },
+                {
+                    arbeidsgiver: {
+                        arbeidsgiver: '972674818',
+                        arbeidsforhold: null,
+                    },
+                    status: 'MOTTATT',
+                    journalpostId: '573777857',
+                },
+            ],
+            vurdering: {
+                kode: '-',
+                beskrivelse: 'Udefinert',
+            },
+            tilVurdering: true,
+            begrunnelse: null,
+        },
+    ],
+};

--- a/src/stories/MainComponent.stories.tsx
+++ b/src/stories/MainComponent.stories.tsx
@@ -3,12 +3,13 @@ import { rest } from 'msw';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import MainComponent from '../ui/MainComponent';
 import ferdigvisning, {
+    alleErMottatt,
     ikkePaakrevd,
     ikkePaakrevdOgManglerInntektsmelding,
     manglerFlereInntektsmeldinger,
     manglerInntektsmelding,
 } from '../../mock/mockedKompletthetsdata';
-import inntektsmeldingPropsMock, { aksjonspunkt9071Props } from '../../mock/inntektsmeldingPropsMock';
+import inntektsmeldingPropsMock, { aksjonspunkt9071FerdigProps, aksjonspunkt9071Props } from '../../mock/inntektsmeldingPropsMock';
 
 export default {
     args: inntektsmeldingPropsMock,
@@ -26,6 +27,7 @@ export const ManglerFlere9071 = Template.bind({});
 export const IkkePaakrevdOgMangler9071 = Template.bind({});
 export const FerdigVisning9069 = Template.bind({});
 export const FerdigVisning9071 = Template.bind({});
+export const AlleInntektsmeldingerMottatt = Template.bind({});
 
 IkkePaakrevd.args = inntektsmeldingPropsMock;
 IkkePaakrevd.parameters = {
@@ -62,9 +64,16 @@ FerdigVisning9069.parameters = {
         handlers: [rest.get('/tilstand', (req, res, ctx) => res(ctx.json(ferdigvisning)))],
     },
 };
-FerdigVisning9071.args = aksjonspunkt9071Props;
+FerdigVisning9071.args = aksjonspunkt9071FerdigProps;
 FerdigVisning9071.parameters = {
     msw: {
         handlers: [rest.get('/tilstand', (req, res, ctx) => res(ctx.json(ferdigvisning)))],
+    },
+};
+
+AlleInntektsmeldingerMottatt.args = aksjonspunkt9071Props;
+AlleInntektsmeldingerMottatt.parameters = {
+    msw: {
+        handlers: [rest.get('/tilstand', (req, res, ctx) => res(ctx.json(alleErMottatt)))],
     },
 };

--- a/src/ui/components/fortsett-uten-inntektsmelding-form/FortsettUtenInntektsmeldingForm.tsx
+++ b/src/ui/components/fortsett-uten-inntektsmelding-form/FortsettUtenInntektsmeldingForm.tsx
@@ -39,7 +39,7 @@ function FortsettUtenInntektsmeldingForm({
 }: FortsettUtenInntektsmeldingFormProps): JSX.Element {
     const { arbeidsforhold, readOnly } = React.useContext(ContainerContext);
 
-    const { watch } = formMethods;
+    const { watch, reset } = formMethods;
     const { beslutningFieldName, begrunnelseFieldName } = tilstand;
     const beslutningId = `beslutning-${tilstand.periodeOpprinneligFormat}`;
     const begrunnelseId = `begrunnelse-${tilstand.periodeOpprinneligFormat}`;
@@ -81,6 +81,11 @@ function FortsettUtenInntektsmeldingForm({
                 },
             ],
         });
+
+    const avbrytRedigering = () => {
+        reset();
+        setRedigeringsmodus(false);
+    };
 
     const radios = {
         '9069': [
@@ -175,7 +180,7 @@ function FortsettUtenInntektsmeldingForm({
                                 </Hovedknapp>
                             )}
                             {redigeringsmodus && (
-                                <Knapp mini onClick={() => setRedigeringsmodus(false)}>
+                                <Knapp mini onClick={avbrytRedigering}>
                                     Avbryt redigering
                                 </Knapp>
                             )}

--- a/src/ui/components/kompletthetsoversikt/Kompletthetsoversikt.tsx
+++ b/src/ui/components/kompletthetsoversikt/Kompletthetsoversikt.tsx
@@ -13,7 +13,7 @@ import {
     finnAktivtAksjonspunkt,
     finnTilstanderSomRedigeres,
     finnTilstanderSomVurderes,
-    ingenTilstanderErPaakrevd,
+    ingenTilstanderHarMangler,
 } from '../../../util/utils';
 import FieldName from '../../../types/FieldName';
 import InntektsmeldingManglerInfo from './InntektsmeldingManglerInfo';
@@ -25,15 +25,16 @@ interface KompletthetsoversiktProps {
 }
 
 const Kompletthetsoversikt = ({ kompletthetsoversikt, onFormSubmit }: KompletthetsoversiktProps): JSX.Element => {
-    const { aksjonspunkter } = React.useContext(ContainerContext);
+    const { aksjonspunkter, readOnly } = React.useContext(ContainerContext);
     const { tilstand: tilstander } = kompletthetsoversikt;
 
     const periods = tilstander.map(({ periode }) => periode);
     const statuses = tilstander.map(({ status }) => status);
     const aktivtAksjonspunkt = finnAktivtAksjonspunkt(aksjonspunkter);
     const forrigeAksjonspunkt = aksjonspunkter.sort((a, b) => Number(b.definisjon.kode) - Number(a.definisjon.kode))[0];
-    const aksjonspunkt = aktivtAksjonspunkt || forrigeAksjonspunkt;
-    const aksjonspunktKode = aksjonspunkt?.definisjon?.kode;
+    const aktivtAksjonspunktKode = aktivtAksjonspunkt?.definisjon?.kode;
+    const forrigeAksjonspunktKode = forrigeAksjonspunkt?.definisjon?.kode;
+    const aksjonspunktKode = aktivtAksjonspunktKode || forrigeAksjonspunktKode
 
     const tilstanderBeriket = tilstander.map((tilstand) => {
         const [redigeringsmodus, setRedigeringsmodus] = useState(false);
@@ -56,6 +57,7 @@ const Kompletthetsoversikt = ({ kompletthetsoversikt, onFormSubmit }: Kompletthe
         mode: 'onTouched',
         defaultValues: tilstanderBeriket.reduce(reducer, {}),
     });
+    const { isDirty } = formMethods.formState;
     const { handleSubmit, watch } = formMethods;
 
     const tilstanderTilVurdering = [
@@ -63,9 +65,17 @@ const Kompletthetsoversikt = ({ kompletthetsoversikt, onFormSubmit }: Kompletthe
         ...finnTilstanderSomRedigeres(tilstanderBeriket),
     ];
 
+
+
     const harFlereTilstanderTilVurdering = tilstanderTilVurdering.length > 1;
-    const kanSendeInn =
-        (harFlereTilstanderTilVurdering || ingenTilstanderErPaakrevd(tilstanderBeriket)) && aksjonspunktKode;
+    const kanSendeInn = () => {
+        if (harFlereTilstanderTilVurdering || ingenTilstanderHarMangler(tilstanderBeriket)) {
+            if (!readOnly) {
+                if (aktivtAksjonspunktKode || (forrigeAksjonspunktKode && isDirty)) return true;
+            }
+        }
+        return false;
+    };
 
     const listItemRenderer = (period: Period) => <InntektsmeldingListe status={statuses[periods.indexOf(period)]} />;
     const listHeadingRenderer = () => <InntektsmeldingListeHeading />;
@@ -73,19 +83,19 @@ const Kompletthetsoversikt = ({ kompletthetsoversikt, onFormSubmit }: Kompletthe
         <div className={styles.kompletthet}>
             <h1 className={styles.kompletthet__mainHeading}>Inntektsmelding</h1>
             <h2 className={styles.kompletthet__subHeading}>Opplysninger til beregning</h2>
-            {aksjonspunkt && <InntektsmeldingManglerInfo />}
+            {aktivtAksjonspunkt && <InntektsmeldingManglerInfo />}
             <Box marginTop={Margin.large}>
                 <PeriodList
                     tilstander={tilstanderBeriket}
                     listHeadingRenderer={listHeadingRenderer}
                     listItemRenderer={listItemRenderer}
                     onFormSubmit={onFormSubmit}
-                    aksjonspunkt={aksjonspunkt}
+                    aksjonspunkt={aktivtAksjonspunkt || forrigeAksjonspunkt}
                     formMethods={formMethods}
                     harFlereTilstanderTilVurdering={harFlereTilstanderTilVurdering}
                 />
             </Box>
-            {kanSendeInn && (
+            {kanSendeInn() && (
                 <Box marginTop={Margin.large}>
                     <form
                         onSubmit={handleSubmit((data) => {

--- a/src/ui/components/kompletthetsoversikt/Kompletthetsoversikt.tsx
+++ b/src/ui/components/kompletthetsoversikt/Kompletthetsoversikt.tsx
@@ -83,7 +83,7 @@ const Kompletthetsoversikt = ({ kompletthetsoversikt, onFormSubmit }: Kompletthe
         <div className={styles.kompletthet}>
             <h1 className={styles.kompletthet__mainHeading}>Inntektsmelding</h1>
             <h2 className={styles.kompletthet__subHeading}>Opplysninger til beregning</h2>
-            {aktivtAksjonspunkt && <InntektsmeldingManglerInfo />}
+            <InntektsmeldingManglerInfo />
             <Box marginTop={Margin.large}>
                 <PeriodList
                     tilstander={tilstanderBeriket}

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -14,7 +14,10 @@ export const skalVurderes = (tilstand: TilstandBeriket): boolean =>
 export const ikkePaakrevd = (tilstand: TilstandBeriket): boolean =>
     tilstand?.status.some((status) => [Status.IKKE_PÅKREVD].includes(status.status));
 
-export const ingenTilstanderErPaakrevd = (tilstander: TilstandBeriket[]) => tilstander.every(ikkePaakrevd);
+export const ingenInntektsmeldingMangler = (tilstand: TilstandBeriket): boolean =>
+    !tilstand?.status.some((status) => [Status.MANGLER].includes(status.status));
+
+export const ingenTilstanderHarMangler = (tilstander: TilstandBeriket[]) => tilstander.every(ingenInntektsmeldingMangler);
 
 export const finnTilstanderSomVurderes = (tilstander: TilstandBeriket[]): TilstandBeriket[] =>
     tilstander.filter(skalVurderes);

--- a/test/Aksjonspunkt9071.spec.tsx
+++ b/test/Aksjonspunkt9071.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
 import { Story } from '@storybook/react';
@@ -62,7 +63,6 @@ describe('9071 - Mangler inntektsmelding', () => {
         // ARRANGE
         const onClickSpy = jest.fn();
         const data = { onFinished: onClickSpy };
-        // eslint-disable-next-line react/jsx-props-no-spreading
         render(<Mangler9071 {...data} />);
 
         await waitFor(() => screen.getByText(/Når kan du gå videre uten inntektsmelding?/i));
@@ -92,7 +92,6 @@ describe('9071 - Mangler inntektsmelding', () => {
         // ARRANGE
         const onClickSpy = jest.fn();
         const data = { onFinished: onClickSpy };
-        // eslint-disable-next-line react/jsx-props-no-spreading
         render(<Mangler9071 {...data} />);
 
         await waitFor(() => screen.getByText(/Når kan du gå videre uten inntektsmelding?/i));
@@ -120,7 +119,8 @@ describe('9071 - Mangler inntektsmelding', () => {
     test('Hvis det tidligere er blitt gjort en vurdering og behandlingen har hoppet tilbake må man kunne løse aksjonspunktet', async () => {
         // ARRANGE
         const onClickSpy = jest.fn();
-        render(<AlleInntektsmeldingerMottatt onFinished={onClickSpy} />);
+        const data = { onFinished: onClickSpy };
+        render(<AlleInntektsmeldingerMottatt {...data} />);
 
         await waitFor(() => screen.getByText(/Når kan du gå videre uten inntektsmelding?/i));
 

--- a/test/Aksjonspunkt9071.spec.tsx
+++ b/test/Aksjonspunkt9071.spec.tsx
@@ -17,7 +17,7 @@ describe('9071 - Mangler inntektsmelding', () => {
 
     afterAll(() => (getWorker() as SetupServerApi).close());
 
-    const { Mangler9071 } = composeStories(stories) as {
+    const { Mangler9071, AlleInntektsmeldingerMottatt } = composeStories(stories) as {
         [key: string]: Story<Partial<typeof MainComponent>>;
     };
 
@@ -115,6 +115,23 @@ describe('9071 - Mangler inntektsmelding', () => {
                     kode: '9071',
                 },
             ],
+        });
+    });
+    test('Hvis det tidligere er blitt gjort en vurdering og behandlingen har hoppet tilbake må man kunne løse aksjonspunktet', async () => {
+        // ARRANGE
+        const onClickSpy = jest.fn();
+        render(<AlleInntektsmeldingerMottatt onFinished={onClickSpy} />);
+
+        await waitFor(() => screen.getByText(/Når kan du gå videre uten inntektsmelding?/i));
+
+        // ACT
+        await userEvent.click(screen.getByRole('button', { name: /Send inn/i }));
+
+        // ASSERT
+        expect(onClickSpy).toBeCalledWith({
+            '@type': '9071',
+            kode: '9071',
+            perioder: [],
         });
     });
 });


### PR DESCRIPTION
Når man har fortsatt uten innteksmelding, men senere har fått alle inntektsmeldinger rulles behandlingen tilbake, og man må løse aksjonpunktet selv om det ikke er noe å gjøre. Viser 'send inn'-knapp i disse tilfellene